### PR TITLE
chore: migrate Loki from grafana upstream to grafana-community fork

### DIFF
--- a/apps/monitoring/loki/app/helmrelease.yaml
+++ b/apps/monitoring/loki/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     name: loki
   interval: 1h
   values:
-    deploymentMode: SingleBinary
+    deploymentMode: Monolithic
     loki:
       auth_enabled: false
       analytics:

--- a/apps/monitoring/loki/app/ocirepository.yaml
+++ b/apps/monitoring/loki/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 6.55.0
-  url: oci://ghcr.io/grafana/helm-charts/loki
+    tag: 17.1.1
+  url: oci://ghcr.io/grafana-community/helm-charts/loki


### PR DESCRIPTION
## Motivation

Der offizielle `grafana/loki` Helm-Chart wurde ab Version **7.0.0** auf Grafana Enterprise Logs (GEL) umgestellt. OSS-User müssen auf den Community-Fork `grafana-community/helm-charts` wechseln.

Siehe: https://github.com/grafana-community/helm-charts

## Änderungen

| Aspekt | Vorher | Nachher |
|---|---|---|
| OCI-URL | `ghcr.io/grafana/helm-charts/loki` | `ghcr.io/grafana-community/helm-charts/loki` |
| Chart-Version | `6.55.0` | `17.1.1` |
| Loki App Version | \~3.x | 3.7.2 |
| deploymentMode | `SingleBinary` | `Monolithic` |
| Source | Offizieller Grafana-Chart | Grafana Community Fork |

## Keine Breaking Changes erwartet

- **Storage**: `filesystem` → wird wie zuvor über `loki.storage.type` gesetzt
- **Schema**: TSDB v13 (unverändert)
- **Ruler/Alertmanager**: über `loki.structuredConfig` (gleicher Mechanismus)
- **Komponenten**: Alle 0-Replica-Komponenten (gateway/backend/read/write) bleiben deaktiviert
- **LokiCanary**: bleibt deaktiviert

## Referenzen

- https://github.com/grafana-community/helm-charts
- Chart v17.1.1: Loki 3.7.2, Kubernetes >= 1.25