### PR TITLE
feat: add hermes-agent ServiceAccount with cluster read-only RBAC

### DIFF
--- a/apps/kube-system/hermes-agent/app/clusterrole.yaml
+++ b/apps/kube-system/hermes-agent/app/clusterrole.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-agent-readonly
+rules:
+  # Core resources — read-only
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+      - pods
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+      - events
+    verbs: ["get", "list", "watch"]
+
+  # Apps API
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+
+  # Batch API
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Autoscaling
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+
+  # Storage
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs: ["get", "list", "watch"]
+
+  # Flux CD
+  - apiGroups: ["kustomize.toolkit.fluxcd.io", "helm.toolkit.fluxcd.io", "source.toolkit.fluxcd.io", "notification.toolkit.fluxcd.io"]
+    resources:
+      - "*"
+    verbs: ["get", "list", "watch"]
+
+  # Cert-Manager
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - issuers
+    verbs: ["get", "list", "watch"]
+
+  # Prometheus / Monitoring
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+      - alertmanagers
+    verbs: ["get", "list", "watch"]
+
+  # Cilium
+  - apiGroups: ["cilium.io"]
+    resources:
+      - ciliumnetworkpolicies
+      - ciliumendpoints
+      - ciliumidentities
+    verbs: ["get", "list", "watch"]
+
+  # Helm
+  - apiGroups: ["helm.cattle.io"]
+    resources:
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+
+  # Events
+  - apiGroups: ["events.k8s.io"]
+    resources:
+      - events
+    verbs: ["get", "list", "watch"]
+
+  # Coordination (leases)
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs: ["get", "list", "watch"]
+
+  # Snapshots
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources:
+      - volumesnapshots
+      - volumesnapshotclasses
+      - volumesnapshotcontents
+    verbs: ["get", "list", "watch"]

--- a/apps/kube-system/hermes-agent/app/clusterrolebinding.yaml
+++ b/apps/kube-system/hermes-agent/app/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-agent-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-agent-readonly
+subjects:
+  - kind: ServiceAccount
+    name: hermes-agent
+    namespace: kube-system

--- a/apps/kube-system/hermes-agent/app/kustomization.yaml
+++ b/apps/kube-system/hermes-agent/app/kustomization.yaml
@@ -2,8 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kube-system
 resources:
-  - ./hermes-agent/ks.yaml
-  - ./reloader/ks.yaml
-  - ./amd-k8s-plugin/ks.yaml
-  - ./cilium/ks.yaml
+  - ./serviceaccount.yaml
+  - ./clusterrole.yaml
+  - ./clusterrolebinding.yaml

--- a/apps/kube-system/hermes-agent/app/serviceaccount.yaml
+++ b/apps/kube-system/hermes-agent/app/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes-agent
+  namespace: kube-system

--- a/apps/kube-system/hermes-agent/ks.yaml
+++ b/apps/kube-system/hermes-agent/ks.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-agent
+  namespace: flux-system
+spec:
+  interval: 1h
+  path: "./apps/kube-system/hermes-agent/app"
+  prune: false # TODO
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false # no flux ks dependents


### PR DESCRIPTION
## Summary

Adds a dedicated ServiceAccount `hermes-agent` in `kube-system` with a cluster-wide read-only ClusterRole, managed via Flux.

### Changes

- **ServiceAccount** `hermes-agent` in `kube-system` namespace
- **ClusterRole** `hermes-agent-readonly` — read-only (`get`, `list`, `watch`) access to:
  - Core resources (pods, nodes, services, namespaces, secrets, PVCs, PVs, configmaps, events)
  - Apps API (deployments, statefulsets, daemonsets)
  - Batch API (jobs, cronjobs)
  - Networking (ingresses, networkpolicies)
  - Storage (storageclasses, volumeattachments, volumesnapshots)
  - Flux CD CRDs (Kustomization, HelmRelease, GitRepository, etc.)
  - Cert-Manager, Prometheus Operator, Cilium, Helm CRDs
- **ClusterRoleBinding** binding the SA to the ClusterRole
- **Flux Kustomization** (`ks.yaml`) added to `kube-system` kustomization

### Usage

After merge, the SA token can be extracted to create a kubeconfig for read-only cluster access:

```bash
kubectl -n kube-system create token hermes-agent --duration=8760h
```

Closes: # (Hermes Agent cluster access)